### PR TITLE
Fix jekyll article_template.ex

### DIFF
--- a/lib/jekyll/article_template.ex
+++ b/lib/jekyll/article_template.ex
@@ -6,7 +6,6 @@ defmodule LoremImpsumMd.Jekyll.ArticleTemplate do
     layout: post
     title: #{title}
     date: #{LoremImpsumMd.Date.now}
-    categories: [Retro Games, Sega, Genesis]
     author: Lorem Ipsum Markdown Generator
     categories: #{inspect categories}
     tags: #{inspect tags}


### PR DESCRIPTION
This can break some markdown parsers. And it's unecessary I guess :)